### PR TITLE
used the proper filename sanitizer

### DIFF
--- a/scripts/squidson
+++ b/scripts/squidson
@@ -2,7 +2,7 @@
 import argparse
 import json as j
 from yt_dlp import YoutubeDL
-from yt_dlp.utils import encodeFilename, sanitize_path
+from yt_dlp.utils import encodeFilename, sanitize_filename
 
 """
 Dump yt_dlp's entire info_dict for a whole playlist in JSON format.
@@ -43,7 +43,7 @@ if __name__ == "__main__":
         y.extract_info(opts.playlist_url, download=False)
     )
 
-    dump_path = encodeFilename(sanitize_path(info_dict["title"] + ".json"))
+    dump_path = encodeFilename(sanitize_filename(info_dict["title"] + ".json"))
     print(
         '[INFO]: Writing JSON-ified playlist info_dict to "{}"'.format(
             dump_path

--- a/squid_dl/downloader.py
+++ b/squid_dl/downloader.py
@@ -38,7 +38,7 @@ from random import randint
 from time import sleep
 import typing
 from yt_dlp import YoutubeDL
-from yt_dlp.utils import encodeFilename, sanitize_path
+from yt_dlp.utils import encodeFilename, sanitize_filename
 from yt_dlp.extractor.common import InfoExtractor as IE
 
 from .linode import LinodeProxy
@@ -233,7 +233,7 @@ def check_dl(in_q: Queue, out_q: Queue):
 
             y = YoutubeDL({"ignoreerrors": True})
             basename = os.path.splitext(
-                sanitize_path(encodeFilename(y.prepare_filename(entry)))
+                sanitize_filename(encodeFilename(y.prepare_filename(entry)))
             )[0]
             try:
                 if check_subs_done(entry, basename):
@@ -458,7 +458,7 @@ def main(args: [str], name: str) -> int:
 
     print("[INFO]: Starting squid-dl...")
 
-    dirname = info_dict["title"]
+    dirname = sanitize_filename(info_dict["title"])
     print('[INFO]: saving videos to "{}" directory'.format(dirname))
     if not (os.path.exists(dirname) and os.path.isdir(dirname)):
         os.mkdir(dirname)


### PR DESCRIPTION
As reported by KajeArch on GitHub on issue #3
(https://github.com/swolegoal/squid-dl/issues/3), I was not correctly
handling playlists named with characters invalid for a file path.  As
it turns out, I was using the wrong helper function from yt_dlp.utils.

I changed all the calls from sanitize_path(), a function made to clean
up Windows paths to the more fully-featured sanitize_filename().  If any
Windows users notice any bad behavior after this change, please feel
free to make a ticket at:
  https://github.com/swolegoal/squid-dl/issues/new/choose